### PR TITLE
Handle pagination for Marktplaats scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Marktplaats Scraper
 
-This repository contains a simple Python script to fetch product listings from a Marktplaats search page.
+This repository contains a simple Python script to fetch product listings from all pages of a Marktplaats search.
 
 ## Usage
 
@@ -16,4 +16,4 @@ pip install -r requirements.txt
 python scrape_marktplaats.py
 ```
 
-The script will output each product's title, price and URL, and print the total number of products scraped from the provided search page.
+The script will output each product's title, price and URL, and print the total number of products scraped across all search result pages.

--- a/scrape_marktplaats.py
+++ b/scrape_marktplaats.py
@@ -1,13 +1,23 @@
 import json
-from typing import List, Dict
+from typing import List, Dict, Any
 import requests
 from bs4 import BeautifulSoup
 
 SEARCH_URL = "https://www.marktplaats.nl/q/solis+espresso+apparaat"
 
 
+def is_commercial(listing: Dict[str, Any]) -> bool:
+    """Return True if the listing is a commercial advertisement."""
+    seller = listing.get("sellerInformation", {})
+    if seller.get("showWebsiteUrl") or seller.get("sellerWebsiteUrl"):
+        return True
+    if listing.get("admarktInfo"):
+        return True
+    return False
+
+
 def fetch_listings(url: str) -> List[Dict[str, str]]:
-    """Return a list of product information dictionaries from a Marktplaats search page."""
+    """Return non-commercial product information dictionaries from a Marktplaats search page."""
     headers = {"User-Agent": "Mozilla/5.0"}
     response = requests.get(url, headers=headers, timeout=30)
     response.raise_for_status()
@@ -20,6 +30,8 @@ def fetch_listings(url: str) -> List[Dict[str, str]]:
     listings = search.get("listings", [])
     products = []
     for item in listings:
+        if is_commercial(item):
+            continue
         price_info = item.get("priceInfo", {})
         price_cents = price_info.get("priceCents")
         price = f"€{price_cents / 100:.2f}" if price_cents is not None else None
@@ -34,8 +46,25 @@ def fetch_listings(url: str) -> List[Dict[str, str]]:
     return products
 
 
+def fetch_all_listings(url: str) -> List[Dict[str, str]]:
+    """Fetch listings from all result pages for a search query."""
+    page = 1
+    all_products: List[Dict[str, str]] = []
+    seen_ids = set()
+    while True:
+        page_url = f"{url}?p={page}" if page > 1 else url
+        products = fetch_listings(page_url)
+        new_products = [p for p in products if p["id"] not in seen_ids]
+        if not new_products:
+            break
+        all_products.extend(new_products)
+        seen_ids.update(p["id"] for p in new_products)
+        page += 1
+    return all_products
+
+
 def main() -> None:
-    products = fetch_listings(SEARCH_URL)
+    products = fetch_all_listings(SEARCH_URL)
     for p in products:
         print(f"{p['title']} - {p['price']} - {p['url']}")
     print(f"Total products scraped: {len(products)}")


### PR DESCRIPTION
## Summary
- add `is_commercial` helper and remove shop ads
- loop through result pages until no new listings remain
- update documentation to note multi-page scraping

## Testing
- `python scrape_marktplaats.py >/tmp/scrape.log && tail -n 20 /tmp/scrape.log`


------
https://chatgpt.com/codex/tasks/task_e_68af151feda4832e8518d8a431d212b7