### PR TITLE
Add web dashboard to view scraped listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ python scrape_marktplaats.py
 ```
 
 The script will output each product's title, price and URL, and print the total number of products scraped across all search result pages.
+
+## Dashboard
+
+To view the listings in a simple web dashboard, run:
+
+```bash
+python dashboard.py
+```
+
+Then open [http://localhost:5000](http://localhost:5000) in your browser to see the table of listings.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,41 @@
+from flask import Flask, render_template_string
+from scrape_marktplaats import fetch_all_listings, SEARCH_URL
+
+app = Flask(__name__)
+
+TEMPLATE = """
+<!doctype html>
+<html>
+<head>
+    <title>Listings Dashboard</title>
+</head>
+<body>
+    <h1>Listings Dashboard</h1>
+    <table border="1">
+        <tr>
+            <th>Title</th>
+            <th>Price</th>
+            <th>Location</th>
+            <th>Link</th>
+        </tr>
+        {% for item in listings %}
+        <tr>
+            <td>{{ item.title }}</td>
+            <td>{{ item.price or 'N/A' }}</td>
+            <td>{{ item.location or 'N/A' }}</td>
+            <td><a href="{{ item.url }}" target="_blank">View</a></td>
+        </tr>
+        {% endfor %}
+    </table>
+    <p>Total products scraped: {{ listings|length }}</p>
+</body>
+</html>
+"""
+
+@app.route("/")
+def index():
+    listings = fetch_all_listings(SEARCH_URL)
+    return render_template_string(TEMPLATE, listings=listings)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+Flask


### PR DESCRIPTION
## Summary
- create simple Flask app serving all scraped listings in a table
- document running the dashboard and add Flask requirement

## Testing
- `python -m py_compile scrape_marktplaats.py dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1df04578832e93659a3dba948ded