### PR TITLE
Add card-based dashboard template with modal details

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,53 +1,14 @@
-from flask import Flask, render_template_string
+from flask import Flask, render_template
 from scrape_marktplaats import fetch_all_listings, SEARCH_URL
 
 app = Flask(__name__)
 
-TEMPLATE = """
-<!doctype html>
-<html>
-<head>
-    <title>Listings Dashboard</title>
-</head>
-<body>
-    <h1>Listings Dashboard</h1>
-    <table border="1">
-        <tr>
- codex/create-dashboard-for-listings-ejd4kb
-            <th>Image</th>
-=======
- main
-            <th>Title</th>
-            <th>Price</th>
-            <th>Location</th>
-            <th>Link</th>
-        </tr>
-        {% for item in listings %}
-        <tr>
- codex/create-dashboard-for-listings-ejd4kb
-            <td>
-                {% if item.image_url %}
-                <img src="{{ item.image_url }}" alt="{{ item.title }}" width="100" />
-                {% else %}N/A{% endif %}
-            </td>
-=======
- main
-            <td>{{ item.title }}</td>
-            <td>{{ item.price or 'N/A' }}</td>
-            <td>{{ item.location or 'N/A' }}</td>
-            <td><a href="{{ item.url }}" target="_blank">View</a></td>
-        </tr>
-        {% endfor %}
-    </table>
-    <p>Total products scraped: {{ listings|length }}</p>
-</body>
-</html>
-"""
 
 @app.route("/")
 def index():
     listings = fetch_all_listings(SEARCH_URL)
-    return render_template_string(TEMPLATE, listings=listings)
+    return render_template("dashboard.html", listings=listings)
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const modalElement = document.getElementById('listingModal');
+  const modal = new bootstrap.Modal(modalElement);
+
+  document.querySelectorAll('.listing-card').forEach(card => {
+    card.addEventListener('click', () => {
+      document.getElementById('modalTitle').textContent = card.dataset.title || '';
+      document.getElementById('modalPrice').textContent = card.dataset.price || 'N/A';
+      document.getElementById('modalLocation').textContent = card.dataset.location || 'N/A';
+      const img = document.getElementById('modalImage');
+      if (card.dataset.image) {
+        img.src = card.dataset.image;
+        img.alt = card.dataset.title || '';
+        img.classList.remove('d-none');
+      } else {
+        img.classList.add('d-none');
+      }
+      const link = document.getElementById('modalUrl');
+      link.href = card.dataset.url;
+      modal.show();
+    });
+  });
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+.listing-card {
+  cursor: pointer;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Listings Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <div class="container my-4">
+    <h1 class="mb-4">Listings Dashboard</h1>
+    <div class="row g-3">
+      {% for item in listings %}
+      <div class="col-md-4">
+        <div class="card listing-card h-100" role="button"
+             data-title="{{ item.title }}"
+             data-price="{{ item.price }}"
+             data-location="{{ item.location }}"
+             data-image="{{ item.image_url }}"
+             data-url="{{ item.url }}">
+          {% if item.image_url %}
+          <img src="{{ item.image_url }}" class="card-img-top" alt="{{ item.title }}">
+          {% endif %}
+          <div class="card-body">
+            <h5 class="card-title">{{ item.title }}</h5>
+            <p class="card-text">{{ item.price or 'N/A' }}<br>{{ item.location or 'N/A' }}</p>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    <p class="mt-3">Total products scraped: {{ listings|length }}</p>
+  </div>
+
+  <div class="modal fade" id="listingModal" tabindex="-1" aria-labelledby="listingModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="modalTitle"></h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <img id="modalImage" class="img-fluid mb-3" alt="">
+          <p><strong>Price:</strong> <span id="modalPrice"></span></p>
+          <p><strong>Location:</strong> <span id="modalLocation"></span></p>
+        </div>
+        <div class="modal-footer">
+          <a id="modalUrl" href="#" target="_blank" class="btn btn-primary">View on Marktplaats</a>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve listings through a dedicated `dashboard.html` template with Bootstrap card layout and modal detail view
- Provide static CSS/JS assets for styling and modal population
- Simplify Flask app to render the template and supply listing data

## Testing
- `python -m py_compile dashboard.py scrape_marktplaats.py`
- `pip install -r requirements.txt`
- `python dashboard.py & PID=$!`


------
https://chatgpt.com/codex/tasks/task_e_68af209ff878832e8f7a3ca2c1a56762