### PR TITLE
Fix HTML template for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,4 @@ To view the listings in a simple web dashboard, run:
 ```bash
 python dashboard.py
 ```
-
-codex/create-dashboard-for-listings-ejd4kb
 Then open [http://localhost:5000](http://localhost:5000) in your browser to see the table of listings with their images.
-=======
-Then open [http://localhost:5000](http://localhost:5000) in your browser to see the table of listings.
-main

--- a/dashboard.py
+++ b/dashboard.py
@@ -13,10 +13,7 @@ TEMPLATE = """
     <h1>Listings Dashboard</h1>
     <table border="1">
         <tr>
- codex/create-dashboard-for-listings-ejd4kb
             <th>Image</th>
-=======
- main
             <th>Title</th>
             <th>Price</th>
             <th>Location</th>
@@ -24,14 +21,11 @@ TEMPLATE = """
         </tr>
         {% for item in listings %}
         <tr>
- codex/create-dashboard-for-listings-ejd4kb
             <td>
                 {% if item.image_url %}
                 <img src="{{ item.image_url }}" alt="{{ item.title }}" width="100" />
                 {% else %}N/A{% endif %}
             </td>
-=======
- main
             <td>{{ item.title }}</td>
             <td>{{ item.price or 'N/A' }}</td>
             <td>{{ item.location or 'N/A' }}</td>


### PR DESCRIPTION
## Summary
- remove leftover merge artifacts from dashboard HTML template
- tidy README dashboard instructions

## Testing
- `pip install -r requirements.txt`
- `python dashboard.py` (and `curl http://127.0.0.1:5000`)


------
https://chatgpt.com/codex/tasks/task_e_68af209e8484832ea01d47ba8ccd8832