### PR TITLE
Remove unused template constant from dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4,43 +4,6 @@ from scrape_marktplaats import fetch_all_listings, SEARCH_URL
 app = Flask(__name__)
 
 
-TEMPLATE = """
-<!doctype html>
-<html>
-<head>
-    <title>Listings Dashboard</title>
-</head>
-<body>
-    <h1>Listings Dashboard</h1>
-    <table border="1">
-        <tr>
-            <th>Image</th>
-            <th>Title</th>
-            <th>Price</th>
-            <th>Location</th>
-            <th>Link</th>
-        </tr>
-        {% for item in listings %}
-        <tr>
-            <td>
-                {% if item.image_url %}
-                <img src="{{ item.image_url }}" alt="{{ item.title }}" width="100" />
-                {% else %}N/A{% endif %}
-            </td>
-            <td>{{ item.title }}</td>
-            <td>{{ item.price or 'N/A' }}</td>
-            <td>{{ item.location or 'N/A' }}</td>
-            <td><a href="{{ item.url }}" target="_blank">View</a></td>
-        </tr>
-        {% endfor %}
-    </table>
-    <p>Total products scraped: {{ listings|length }}</p>
-</body>
-</html>
-"""
-=======
-main
-
 @app.route("/")
 def index():
     listings = fetch_all_listings(SEARCH_URL)


### PR DESCRIPTION
## Summary
- delete obsolete `TEMPLATE` constant from `dashboard.py`
- keep Flask view using `render_template` to serve `dashboard.html`

## Testing
- `python -m py_compile dashboard.py`
- `python - <<'PY'
import dashboard

def fake_fetch(url):
    return [{"title":"Sample","price":"€10.00","location":"Amsterdam","image_url":None,"url":"http://example.com"}]

dashboard.fetch_all_listings = fake_fetch
client = dashboard.app.test_client()
resp = client.get('/')
print('Status:', resp.status_code)
print(resp.data.decode()[:200])
PY`
- `python dashboard.py &
SERVER_PID=$!
sleep 1
kill $SERVER_PID
wait $SERVER_PID 2>/dev/null
`

------
https://chatgpt.com/codex/tasks/task_e_68af22e751b4832eba1bbc9b921a0a8b