### PR TITLE
Show additional listing details in modal

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,45 +1,9 @@
 from flask import Flask, render_template
 from scrape_marktplaats import fetch_all_listings, SEARCH_URL
 
+
 app = Flask(__name__)
 
-
-TEMPLATE = """
-<!doctype html>
-<html>
-<head>
-    <title>Listings Dashboard</title>
-</head>
-<body>
-    <h1>Listings Dashboard</h1>
-    <table border="1">
-        <tr>
-            <th>Image</th>
-            <th>Title</th>
-            <th>Price</th>
-            <th>Location</th>
-            <th>Link</th>
-        </tr>
-        {% for item in listings %}
-        <tr>
-            <td>
-                {% if item.image_url %}
-                <img src="{{ item.image_url }}" alt="{{ item.title }}" width="100" />
-                {% else %}N/A{% endif %}
-            </td>
-            <td>{{ item.title }}</td>
-            <td>{{ item.price or 'N/A' }}</td>
-            <td>{{ item.location or 'N/A' }}</td>
-            <td><a href="{{ item.url }}" target="_blank">View</a></td>
-        </tr>
-        {% endfor %}
-    </table>
-    <p>Total products scraped: {{ listings|length }}</p>
-</body>
-</html>
-"""
-=======
-main
 
 @app.route("/")
 def index():
@@ -49,3 +13,4 @@ def index():
 
 if __name__ == "__main__":
     app.run(debug=True)
+

--- a/static/script.js
+++ b/static/script.js
@@ -7,6 +7,10 @@ document.addEventListener('DOMContentLoaded', function () {
       document.getElementById('modalTitle').textContent = card.dataset.title || '';
       document.getElementById('modalPrice').textContent = card.dataset.price || 'N/A';
       document.getElementById('modalLocation').textContent = card.dataset.location || 'N/A';
+      document.getElementById('modalDate').textContent = card.dataset.date || 'N/A';
+      document.getElementById('modalSeller').textContent = card.dataset.seller || 'N/A';
+      document.getElementById('modalShipping').textContent = card.dataset.shipping || 'N/A';
+      document.getElementById('modalDescription').textContent = card.dataset.description || 'No description available';
       const img = document.getElementById('modalImage');
       if (card.dataset.image) {
         img.src = card.dataset.image;

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,20 @@
 .listing-card {
   cursor: pointer;
 }
+
+.modal-body {
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.modal-body p {
+  margin-bottom: 0.5rem;
+}
+
+#modalDescription {
+  white-space: pre-wrap;
+}
+
+.listing-card .badge + .badge {
+  margin-left: 0.25rem;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,19 +12,29 @@
     <h1 class="mb-4">Listings Dashboard</h1>
     <div class="row g-3">
       {% for item in listings %}
-      <div class="col-md-4">
+      <div class="col-sm-6 col-md-4 col-lg-3">
         <div class="card listing-card h-100" role="button"
              data-title="{{ item.title }}"
              data-price="{{ item.price }}"
              data-location="{{ item.location }}"
              data-image="{{ item.image_url }}"
-             data-url="{{ item.url }}">
+             data-url="{{ item.url }}"
+             data-description="{{ item.description }}"
+             data-seller="{{ item.seller }}"
+             data-date="{{ item.posting_date }}"
+             data-shipping="{{ item.shipping_info }}">
           {% if item.image_url %}
           <img src="{{ item.image_url }}" class="card-img-top" alt="{{ item.title }}">
           {% endif %}
           <div class="card-body">
             <h5 class="card-title">{{ item.title }}</h5>
             <p class="card-text">{{ item.price or 'N/A' }}<br>{{ item.location or 'N/A' }}</p>
+            {% if item.seller and 'pro' in item.seller|lower %}
+            <span class="badge bg-info text-dark">Pro Seller</span>
+            {% endif %}
+            {% if item.shipping_info %}
+            <span class="badge bg-success">Shipping</span>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -44,6 +54,10 @@
           <img id="modalImage" class="img-fluid mb-3" alt="">
           <p><strong>Price:</strong> <span id="modalPrice"></span></p>
           <p><strong>Location:</strong> <span id="modalLocation"></span></p>
+          <p><strong>Date:</strong> <span id="modalDate"></span></p>
+          <p><strong>Seller:</strong> <span id="modalSeller"></span></p>
+          <p><strong>Shipping:</strong> <span id="modalShipping"></span></p>
+          <p id="modalDescription" class="mt-3"></p>
         </div>
         <div class="modal-footer">
           <a id="modalUrl" href="#" target="_blank" class="btn btn-primary">View on Marktplaats</a>


### PR DESCRIPTION
## Summary
- Expand dashboard cards with extra data attributes and badges
- Populate and style a richer listing modal
- Clean up dashboard backend entry point

## Testing
- `python -m py_compile dashboard.py scrape_marktplaats.py`

------
https://chatgpt.com/codex/tasks/task_e_68af22e6b22c832e9912ad1427acf751