### PR TITLE
Load dashboard listings from file and gate debug mode

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,12 +1,19 @@
+import json
+import os
+from pathlib import Path
+
 from flask import Flask, render_template
-from scrape_marktplaats import fetch_all_listings, SEARCH_URL
 
 app = Flask(__name__)
 
 @app.route("/")
 def index():
-    listings = fetch_all_listings(SEARCH_URL)
+    data_file = Path("marktplaats_listings.json")
+    if data_file.exists():
+        listings = json.loads(data_file.read_text())
+    else:
+        listings = None
     return render_template("dashboard.html", listings=listings)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=os.getenv("FLASK_DEBUG") == "1")


### PR DESCRIPTION
## Summary
- Load listing data from `marktplaats_listings.json` if available, otherwise pass `None` to the template
- Gate Flask debug mode behind `FLASK_DEBUG` environment variable

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3654d96c832ea4c4ecb414ea0a32