### PR TITLE
refactor: extract shared headers

### DIFF
--- a/scrape_marktplaats.py
+++ b/scrape_marktplaats.py
@@ -18,6 +18,20 @@ from bs4 import BeautifulSoup
 
 SEARCH_URL = "https://www.marktplaats.nl/q/solis+espresso+apparaat"
 
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "TE": "trailers",
+}
+
 
 def is_commercial(listing: Dict[str, Any]) -> bool:
     """Return True if the listing is a commercial advertisement."""
@@ -54,20 +68,7 @@ def fetch_listing_details(vip_url: str) -> Dict[str, Any]:
         cannot be located.
     """
 
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Connection": "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-        "Sec-Fetch-Dest": "document",
-        "Sec-Fetch-Mode": "navigate",
-        "Sec-Fetch-Site": "none",
-        "Sec-Fetch-User": "?1",
-        "TE": "trailers",
-    }
-    response = requests.get(vip_url, headers=headers, timeout=30)
+    response = requests.get(vip_url, headers=DEFAULT_HEADERS, timeout=30)
     response.raise_for_status()
     soup = BeautifulSoup(response.text, "html.parser")
     try:
@@ -103,20 +104,7 @@ def fetch_listings(url: str) -> List[Dict[str, Any]]:
     fall back to fetching the listing's detail page.
     """
 
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Connection": "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-        "Sec-Fetch-Dest": "document",
-        "Sec-Fetch-Mode": "navigate",
-        "Sec-Fetch-Site": "none",
-        "Sec-Fetch-User": "?1",
-        "TE": "trailers",
-    }
-    response = requests.get(url, headers=headers, timeout=30)
+    response = requests.get(url, headers=DEFAULT_HEADERS, timeout=30)
     response.raise_for_status()
     soup = BeautifulSoup(response.text, "html.parser")
     data = _parse_listing_script(soup)


### PR DESCRIPTION
## Summary
- centralize shared request headers in `DEFAULT_HEADERS`
- reference `DEFAULT_HEADERS` in listing fetch helpers

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3658df2c832e86dc98749b0ac5c9