### PR TITLE
Add randomized delay after listing detail fetches

### DIFF
--- a/scrape_marktplaats.py
+++ b/scrape_marktplaats.py
@@ -10,6 +10,7 @@ data.
 """
 
 import json
+import random
 import sqlite3
 import time
 from datetime import datetime
@@ -143,7 +144,6 @@ def mark_listings_active(conn: sqlite3.Connection, ids: List[str]) -> None:
 def notify_new_listing(listing: Dict[str, Any]) -> None:
     """Send an alert for a newly discovered listing."""
     print(f"New listing: {listing.get('title')} -> {listing.get('url')}")
- main
 
 
 def is_commercial(listing: Dict[str, Any]) -> bool:
@@ -284,6 +284,7 @@ def fetch_listings(url: str) -> List[Dict[str, Any]]:
 
         # Fill in any missing fields from the listing detail page.
         details = fetch_listing_details(product["url"])
+        time.sleep(random.uniform(1, 2))
         for key, value in details.items():
             if product.get(key) in (None, [], {}):
                 product[key] = value


### PR DESCRIPTION
## Summary
- introduce random 1-2 second delay after fetching listing details to slow requests
- import random module to support randomized sleep

## Testing
- `python -m py_compile scrape_marktplaats.py`

------
https://chatgpt.com/codex/tasks/task_e_68af3af0054c832eac6938ecf3da2ceb